### PR TITLE
Bundle and apply ZAP license to Java code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Configure Spotless' Java extension with the ZAP license.
+
 ### Changed
 - Recommended minimum Gradle version is now 8.2.
 

--- a/src/functionalTest/java/org/zaproxy/gradle/common/spotless/FormatPropertiesStepFunctionalTest.java
+++ b/src/functionalTest/java/org/zaproxy/gradle/common/spotless/FormatPropertiesStepFunctionalTest.java
@@ -22,34 +22,25 @@ package org.zaproxy.gradle.common.spotless;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 
-import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Properties;
-import java.util.stream.Collectors;
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-public class FormatPropertiesStepFunctionalTest {
+class FormatPropertiesStepFunctionalTest extends FunctionalTest {
     @Test
-    void shouldFormatProperties(@TempDir File testProjectDir) throws Exception {
+    void shouldFormatProperties() throws Exception {
         // Given
         Path originalBuildFilePath =
                 Path.of(getClass().getResource("spotlessProperties.gradle.kts").toURI());
-        Path copiedBuildFilePath = testProjectDir.toPath().resolve("build.gradle.kts");
+        Path copiedBuildFilePath = projectDir.resolve("build.gradle.kts");
         Path originalUnformattedPropertiesPath =
                 Path.of(getClass().getResource("unformatted.properties").toURI());
-        Path copiedUnformattedPropertiesPath =
-                testProjectDir.toPath().resolve("unformatted.properties");
+        Path copiedUnformattedPropertiesPath = projectDir.resolve("unformatted.properties");
         Path formattedPropertiesPath =
                 Path.of(getClass().getResource("formatted.properties").toURI());
         String spotlessPropertiesApplyTaskName = ":spotlessPropertiesApply";
@@ -57,25 +48,12 @@ public class FormatPropertiesStepFunctionalTest {
         Files.copy(originalUnformattedPropertiesPath, copiedUnformattedPropertiesPath);
         Files.copy(originalBuildFilePath, copiedBuildFilePath);
         // When
-        Path pluginClasspath =
-                Path.of(getClass().getClassLoader().getResource("pluginClasspath.txt").toURI());
-        List<File> pluginClasspathFiles =
-                Files.readAllLines(pluginClasspath).stream()
-                        .map(File::new)
-                        .collect(Collectors.toList());
-        BuildResult result =
-                GradleRunner.create()
-                        .withProjectDir(testProjectDir)
-                        .withArguments(spotlessPropertiesApplyTaskName)
-                        .withPluginClasspath(pluginClasspathFiles)
-                        .build();
+        BuildResult result = build(spotlessPropertiesApplyTaskName);
         // Then
-        BuildTask spotlessPropertiesApplyTask = result.task(spotlessPropertiesApplyTaskName);
-        assertThat(spotlessPropertiesApplyTask, is(notNullValue()));
-        assertThat(spotlessPropertiesApplyTask.getOutcome(), is(TaskOutcome.SUCCESS));
+        assertTaskSuccess(result, spotlessPropertiesApplyTaskName);
         assertThat(
-                Files.readString(copiedUnformattedPropertiesPath, StandardCharsets.UTF_8),
-                is(equalTo(Files.readString(formattedPropertiesPath, StandardCharsets.UTF_8))));
+                contentOf(copiedUnformattedPropertiesPath),
+                is(equalTo(contentOf(formattedPropertiesPath))));
 
         var properties = new Properties();
         properties.load(

--- a/src/functionalTest/java/org/zaproxy/gradle/common/spotless/FunctionalTest.java
+++ b/src/functionalTest/java/org/zaproxy/gradle/common/spotless/FunctionalTest.java
@@ -1,0 +1,79 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.common.spotless;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.io.TempDir;
+
+abstract class FunctionalTest {
+
+    @TempDir protected Path projectDir;
+
+    protected static String contentOf(Path file) throws IOException {
+        return Files.readString(file);
+    }
+
+    protected static void createFile(String content, Path file) throws Exception {
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content);
+    }
+
+    protected void buildFile(String content) throws Exception {
+        createFile(content, projectDir.resolve("build.gradle.kts"));
+    }
+
+    protected static Iterable<? extends File> pluginClasspath() throws Exception {
+        Path pluginClasspath =
+                Path.of(
+                        FunctionalTest.class
+                                .getClassLoader()
+                                .getResource("pluginClasspath.txt")
+                                .toURI());
+        return Files.readAllLines(pluginClasspath).stream()
+                .map(File::new)
+                .collect(Collectors.toList());
+    }
+
+    protected BuildResult build(String... arguments) throws Exception {
+        return GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withArguments(arguments)
+                .withPluginClasspath(pluginClasspath())
+                .build();
+    }
+
+    protected static void assertTaskSuccess(BuildResult result, String taskName) {
+        BuildTask task = result.task(taskName);
+        assertThat(task, is(notNullValue()));
+        assertThat(task.getOutcome(), is(TaskOutcome.SUCCESS));
+    }
+}

--- a/src/functionalTest/java/org/zaproxy/gradle/common/spotless/JavaLicenseFunctionalTest.java
+++ b/src/functionalTest/java/org/zaproxy/gradle/common/spotless/JavaLicenseFunctionalTest.java
@@ -1,0 +1,83 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.common.spotless;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.jupiter.api.Test;
+
+class JavaLicenseFunctionalTest extends FunctionalTest {
+
+    private static final String SPOTLESS_APPLY = ":spotlessApply";
+
+    private static final String CONTENT_JAVA_FILE = "package org.zaproxy.example;";
+
+    @Test
+    void shouldNotFormatIfJavaPluginNotApplied() throws Exception {
+        // Given
+        buildFile(
+                "plugins {\n"
+                        + "    id(\"com.diffplug.spotless\")\n"
+                        + "    id(\"org.zaproxy.common\")\n"
+                        + "}");
+        var javaFile = createJavaFile();
+        // When
+        BuildResult result = build(SPOTLESS_APPLY);
+        // Then
+        assertTaskSuccess(result, SPOTLESS_APPLY);
+        assertThat(contentOf(javaFile), is(equalTo(CONTENT_JAVA_FILE)));
+    }
+
+    @Test
+    void shouldFormatWithJavaLicense() throws Exception {
+        // Given
+        buildFile(
+                "plugins {\n"
+                        + "    `java-library`\n"
+                        + "    id(\"com.diffplug.spotless\")\n"
+                        + "    id(\"org.zaproxy.common\")\n"
+                        + "}");
+        var javaFile = createJavaFile();
+        // When
+        BuildResult result = build(SPOTLESS_APPLY);
+        // Then
+        assertTaskSuccess(result, SPOTLESS_APPLY);
+        assertThat(
+                contentOf(javaFile),
+                allOf(
+                        startsWith("/*"),
+                        containsString("Zed Attack Proxy (ZAP) and its related class files."),
+                        endsWith(CONTENT_JAVA_FILE)));
+    }
+
+    private Path createJavaFile() throws Exception {
+        var javaFile = projectDir.resolve("src/main/java/org/zaproxy/example/Example.java");
+        createFile(CONTENT_JAVA_FILE, javaFile);
+        return javaFile;
+    }
+}

--- a/src/main/resources/org/zaproxy/gradle/common/spotless/license.java
+++ b/src/main/resources/org/zaproxy/gradle/common/spotless/license.java
@@ -1,0 +1,19 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright $YEAR The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */


### PR DESCRIPTION
Automatically configure the Spotless' Java extension with the ZAP license when the Java plugin is applied.
Extract test code to base class to avoid code duplication.