### PR TITLE
Configure `JavaCompile` tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Configure Spotless' Java extension with the ZAP license.
+- Configure the `JavaCompile` tasks to use UTF-8, enable all warnings, and handle warnings as errors.
 
 ### Changed
 - Recommended minimum Gradle version is now 8.2.

--- a/src/functionalTest/java/org/zaproxy/gradle/common/FunctionalTest.java
+++ b/src/functionalTest/java/org/zaproxy/gradle/common/FunctionalTest.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.gradle.common.spotless;
+package org.zaproxy.gradle.common;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -34,7 +34,7 @@ import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.io.TempDir;
 
-abstract class FunctionalTest {
+public abstract class FunctionalTest {
 
     @TempDir protected Path projectDir;
 
@@ -72,8 +72,17 @@ abstract class FunctionalTest {
     }
 
     protected static void assertTaskSuccess(BuildResult result, String taskName) {
+        assertTaskOutcome(result, taskName, TaskOutcome.SUCCESS);
+    }
+
+    private static void assertTaskOutcome(
+            BuildResult result, String taskName, TaskOutcome outcome) {
         BuildTask task = result.task(taskName);
         assertThat(task, is(notNullValue()));
-        assertThat(task.getOutcome(), is(TaskOutcome.SUCCESS));
+        assertThat(task.getOutcome(), is(outcome));
+    }
+
+    protected static void assertTaskFailed(BuildResult result, String taskName) {
+        assertTaskOutcome(result, taskName, TaskOutcome.FAILED);
     }
 }

--- a/src/functionalTest/java/org/zaproxy/gradle/common/JavaCompileFunctionalTest.java
+++ b/src/functionalTest/java/org/zaproxy/gradle/common/JavaCompileFunctionalTest.java
@@ -1,0 +1,84 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.UnexpectedBuildFailure;
+import org.junit.jupiter.api.Test;
+
+class JavaCompileFunctionalTest extends FunctionalTest {
+
+    private static final String COMPILE_JAVA = ":compileJava";
+
+    @Test
+    void shouldCompileWithUnicodeChars() throws Exception {
+        // Given
+        buildFileWithJavaPlugin();
+        javaClassWith("        String str = \"❌🎉️\"; System.out.println(str);\n");
+        // When
+        BuildResult result = build(COMPILE_JAVA);
+        // Then
+        assertTaskSuccess(result, COMPILE_JAVA);
+    }
+
+    private void buildFileWithJavaPlugin() throws Exception {
+        buildFile(
+                "plugins {\n"
+                        + "    `java-library`\n"
+                        + "    id(\"com.diffplug.spotless\")\n"
+                        + "    id(\"org.zaproxy.common\")\n"
+                        + "}");
+    }
+
+    @Test
+    void shouldFailWithWarningsAsErrors() throws Exception {
+        // Given
+        buildFileWithJavaPlugin();
+        javaClassWith(
+                "        java.util.List l = new java.util.ArrayList<Number>();\n"
+                        + "        java.util.List<String> ls = l;\n");
+        // When / Then
+        UnexpectedBuildFailure ex =
+                assertThrows(UnexpectedBuildFailure.class, () -> build(COMPILE_JAVA));
+        BuildResult result = ex.getBuildResult();
+        assertTaskFailed(result, COMPILE_JAVA);
+        assertThat(
+                result.getOutput(), containsString("error: warnings found and -Werror specified"));
+    }
+
+    private Path javaClassWith(String body) throws Exception {
+        var javaFile = projectDir.resolve("src/main/java/org/zaproxy/example/Example.java");
+        createFile(
+                "package org.zaproxy.example;\n"
+                        + "\n"
+                        + "public class Example {\n"
+                        + "    public static void main(String[] args) {\n"
+                        + body
+                        + "    }\n"
+                        + "}",
+                javaFile);
+        return javaFile;
+    }
+}

--- a/src/functionalTest/java/org/zaproxy/gradle/common/spotless/FormatPropertiesStepFunctionalTest.java
+++ b/src/functionalTest/java/org/zaproxy/gradle/common/spotless/FormatPropertiesStepFunctionalTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.util.Properties;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.Test;
+import org.zaproxy.gradle.common.FunctionalTest;
 
 class FormatPropertiesStepFunctionalTest extends FunctionalTest {
     @Test

--- a/src/functionalTest/java/org/zaproxy/gradle/common/spotless/JavaLicenseFunctionalTest.java
+++ b/src/functionalTest/java/org/zaproxy/gradle/common/spotless/JavaLicenseFunctionalTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.startsWith;
 import java.nio.file.Path;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.Test;
+import org.zaproxy.gradle.common.FunctionalTest;
 
 class JavaLicenseFunctionalTest extends FunctionalTest {
 

--- a/src/main/java/org/zaproxy/gradle/common/CommonPlugin.java
+++ b/src/main/java/org/zaproxy/gradle/common/CommonPlugin.java
@@ -22,14 +22,18 @@ package org.zaproxy.gradle.common;
 import com.diffplug.gradle.spotless.SpotlessExtension;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.ProjectConfigurationException;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.compile.JavaCompile;
 import org.zaproxy.gradle.common.spotless.FormatPropertiesStep;
 
 /** A plugin for common ZAP build-related configs and tasks. */
 public class CommonPlugin implements Plugin<Project> {
+
+    private static final List<String> JAVA_COMPILER_ARGS = List.of("-Xlint:all", "-Werror");
 
     @Override
     public void apply(Project target) {
@@ -53,6 +57,16 @@ public class CommonPlugin implements Plugin<Project> {
     private static void configureJavaPlugin(Project target) {
         target.getExtensions()
                 .configure(SpotlessExtension.class, CommonPlugin::configureSpotlessJava);
+
+        target.getTasks()
+                .withType(JavaCompile.class)
+                .configureEach(CommonPlugin::configureJavaCompile);
+    }
+
+    private static void configureJavaCompile(JavaCompile task) {
+        var options = task.getOptions();
+        options.setEncoding(StandardCharsets.UTF_8.name());
+        options.setCompilerArgs(JAVA_COMPILER_ARGS);
     }
 
     private static void configureSpotlessJava(SpotlessExtension ext) {


### PR DESCRIPTION
Configure the tasks to use UTF-8, enable all warnings, and handle warnings as errors.