### PR TITLE
Configure Java Spotless with GJF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Configure Spotless' Java extension with the ZAP license.
+- Configure Spotless' Java extension with the ZAP license and Google Java Format (AOSP).
 - Configure the `JavaCompile` tasks to use UTF-8, enable all warnings, and handle warnings as errors.
 
 ### Changed

--- a/src/functionalTest/java/org/zaproxy/gradle/common/JavaCompileFunctionalTest.java
+++ b/src/functionalTest/java/org/zaproxy/gradle/common/JavaCompileFunctionalTest.java
@@ -26,16 +26,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.nio.file.Path;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class JavaCompileFunctionalTest extends FunctionalTest {
+class JavaCompileFunctionalTest extends JavaFunctionalTest {
 
     private static final String COMPILE_JAVA = ":compileJava";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        buildFileWithJavaPlugin();
+    }
 
     @Test
     void shouldCompileWithUnicodeChars() throws Exception {
         // Given
-        buildFileWithJavaPlugin();
         javaClassWith("        String str = \"❌🎉️\"; System.out.println(str);\n");
         // When
         BuildResult result = build(COMPILE_JAVA);
@@ -43,19 +48,9 @@ class JavaCompileFunctionalTest extends FunctionalTest {
         assertTaskSuccess(result, COMPILE_JAVA);
     }
 
-    private void buildFileWithJavaPlugin() throws Exception {
-        buildFile(
-                "plugins {\n"
-                        + "    `java-library`\n"
-                        + "    id(\"com.diffplug.spotless\")\n"
-                        + "    id(\"org.zaproxy.common\")\n"
-                        + "}");
-    }
-
     @Test
     void shouldFailWithWarningsAsErrors() throws Exception {
         // Given
-        buildFileWithJavaPlugin();
         javaClassWith(
                 "        java.util.List l = new java.util.ArrayList<Number>();\n"
                         + "        java.util.List<String> ls = l;\n");

--- a/src/functionalTest/java/org/zaproxy/gradle/common/JavaFunctionalTest.java
+++ b/src/functionalTest/java/org/zaproxy/gradle/common/JavaFunctionalTest.java
@@ -1,0 +1,54 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.common;
+
+import java.nio.file.Path;
+
+public abstract class JavaFunctionalTest extends FunctionalTest {
+
+    protected static final String CONTENT_JAVA_FILE = "package org.zaproxy.example;";
+
+    protected void buildFileWithoutJavaPlugin() throws Exception {
+        buildFile(
+                "plugins {\n"
+                        + "    id(\"com.diffplug.spotless\")\n"
+                        + "    id(\"org.zaproxy.common\")\n"
+                        + "}");
+    }
+
+    protected void buildFileWithJavaPlugin() throws Exception {
+        buildFile(
+                "plugins {\n"
+                        + "    `java-library`\n"
+                        + "    id(\"com.diffplug.spotless\")\n"
+                        + "    id(\"org.zaproxy.common\")\n"
+                        + "}\n"
+                        + "\n"
+                        + "repositories {\n"
+                        + "    mavenCentral()\n"
+                        + "}");
+    }
+
+    protected Path createJavaFile() throws Exception {
+        var javaFile = projectDir.resolve("src/main/java/org/zaproxy/example/Example.java");
+        createFile(CONTENT_JAVA_FILE, javaFile);
+        return javaFile;
+    }
+}

--- a/src/functionalTest/java/org/zaproxy/gradle/common/spotless/JavaFormatFunctionalTest.java
+++ b/src/functionalTest/java/org/zaproxy/gradle/common/spotless/JavaFormatFunctionalTest.java
@@ -20,17 +20,15 @@
 package org.zaproxy.gradle.common.spotless;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.startsWith;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.gradle.common.JavaFunctionalTest;
 
-class JavaLicenseFunctionalTest extends JavaFunctionalTest {
+class JavaFormatFunctionalTest extends JavaFunctionalTest {
 
     private static final String SPOTLESS_APPLY = ":spotlessApply";
 
@@ -47,7 +45,7 @@ class JavaLicenseFunctionalTest extends JavaFunctionalTest {
     }
 
     @Test
-    void shouldFormatWithJavaLicense() throws Exception {
+    void shouldFormatWithGjf() throws Exception {
         // Given
         buildFileWithJavaPlugin();
         var javaFile = createJavaFile();
@@ -55,12 +53,6 @@ class JavaLicenseFunctionalTest extends JavaFunctionalTest {
         BuildResult result = build(SPOTLESS_APPLY);
         // Then
         assertTaskSuccess(result, SPOTLESS_APPLY);
-        assertThat(
-                contentOf(javaFile),
-                allOf(
-                        startsWith("/*"),
-                        containsString("Zed Attack Proxy (ZAP) and its related class files."),
-                        containsString("*/"),
-                        containsString(CONTENT_JAVA_FILE)));
+        assertThat(contentOf(javaFile), endsWith(CONTENT_JAVA_FILE + "\n"));
     }
 }

--- a/src/main/java/org/zaproxy/gradle/common/CommonPlugin.java
+++ b/src/main/java/org/zaproxy/gradle/common/CommonPlugin.java
@@ -35,6 +35,8 @@ public class CommonPlugin implements Plugin<Project> {
 
     private static final List<String> JAVA_COMPILER_ARGS = List.of("-Xlint:all", "-Werror");
 
+    private static final String GJF_VERSION = "1.17.0";
+
     @Override
     public void apply(Project target) {
         var spotlessExtension = target.getExtensions().findByType(SpotlessExtension.class);
@@ -70,7 +72,11 @@ public class CommonPlugin implements Plugin<Project> {
     }
 
     private static void configureSpotlessJava(SpotlessExtension ext) {
-        ext.java(j -> j.licenseHeader(readLicense()));
+        ext.java(
+                j -> {
+                    j.licenseHeader(readLicense());
+                    j.googleJavaFormat(GJF_VERSION).aosp();
+                });
     }
 
     private static String readLicense() {


### PR DESCRIPTION
Automatically configure the Spotless' Java extension with the Google Java Format when the Java plugin is applied.
Extract test code to avoid code duplication.