### PR TITLE
Compile with `-parameters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Configure the `JavaCompile` tasks with the `-parameters` argument.
 
 ## [0.2.0] - 2023-11-30
 ### Added

--- a/src/main/java/org/zaproxy/gradle/common/CommonPlugin.java
+++ b/src/main/java/org/zaproxy/gradle/common/CommonPlugin.java
@@ -33,7 +33,8 @@ import org.zaproxy.gradle.common.spotless.FormatPropertiesStep;
 /** A plugin for common ZAP build-related configs and tasks. */
 public class CommonPlugin implements Plugin<Project> {
 
-    private static final List<String> JAVA_COMPILER_ARGS = List.of("-Xlint:all", "-Werror");
+    private static final List<String> JAVA_COMPILER_ARGS =
+            List.of("-Xlint:all", "-Werror", "-parameters");
 
     private static final String GJF_VERSION = "1.17.0";
 


### PR DESCRIPTION
Include the names of the parameters so they can be retrieved with reflection, e.g. allowing the Script Console to show proper names.