### PR TITLE
Use text blocks where appropriate

### DIFF
--- a/src/functionalTest/java/org/zaproxy/gradle/common/JavaCompileFunctionalTest.java
+++ b/src/functionalTest/java/org/zaproxy/gradle/common/JavaCompileFunctionalTest.java
@@ -51,8 +51,10 @@ class JavaCompileFunctionalTest extends JavaFunctionalTest {
     void shouldFailWithWarningsAsErrors() throws Exception {
         // Given
         javaClassWith(
-                "        java.util.List l = new java.util.ArrayList<Number>();\n"
-                        + "        java.util.List<String> ls = l;\n");
+                """
+                        java.util.List l = new java.util.ArrayList<Number>();
+                        java.util.List<String> ls = l;
+                """);
         // When / Then
         UnexpectedBuildFailure ex =
                 assertThrows(UnexpectedBuildFailure.class, () -> build(COMPILE_JAVA));
@@ -64,13 +66,15 @@ class JavaCompileFunctionalTest extends JavaFunctionalTest {
     private Path javaClassWith(String body) throws Exception {
         var javaFile = projectDir.resolve("src/main/java/org/zaproxy/example/Example.java");
         createFile(
-                "package org.zaproxy.example;\n"
-                        + "\n"
-                        + "public class Example {\n"
-                        + "    public static void main(String[] args) {\n"
-                        + body
-                        + "    }\n"
-                        + "}",
+                """
+                package org.zaproxy.example;
+
+                public class Example {
+                    public static void main(String[] args) {
+                        %s
+                    }
+                }"""
+                        .formatted(body),
                 javaFile);
         return javaFile;
     }

--- a/src/functionalTest/java/org/zaproxy/gradle/common/JavaFunctionalTest.java
+++ b/src/functionalTest/java/org/zaproxy/gradle/common/JavaFunctionalTest.java
@@ -27,23 +27,25 @@ public abstract class JavaFunctionalTest extends FunctionalTest {
 
     protected void buildFileWithoutJavaPlugin() throws Exception {
         buildFile(
-                "plugins {\n"
-                        + "    id(\"com.diffplug.spotless\")\n"
-                        + "    id(\"org.zaproxy.common\")\n"
-                        + "}");
+                """
+                plugins {
+                    id("com.diffplug.spotless")
+                    id("org.zaproxy.common")
+                }""");
     }
 
     protected void buildFileWithJavaPlugin() throws Exception {
         buildFile(
-                "plugins {\n"
-                        + "    `java-library`\n"
-                        + "    id(\"com.diffplug.spotless\")\n"
-                        + "    id(\"org.zaproxy.common\")\n"
-                        + "}\n"
-                        + "\n"
-                        + "repositories {\n"
-                        + "    mavenCentral()\n"
-                        + "}");
+                """
+                plugins {
+                    `java-library`
+                    id("com.diffplug.spotless")
+                    id("org.zaproxy.common")
+                }
+
+                repositories {
+                    mavenCentral()
+                }""");
     }
 
     protected Path createJavaFile() throws Exception {

--- a/src/test/java/org/zaproxy/gradle/common/spotless/FormatPropertiesStepTest.java
+++ b/src/test/java/org/zaproxy/gradle/common/spotless/FormatPropertiesStepTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
-public class FormatPropertiesStepTest {
+class FormatPropertiesStepTest {
     @Test
     void shouldTrimSpacesBeforeSeparator() throws Exception {
         assertThat(FormatPropertiesStep.format("spaces.before.separator     = value\n"))


### PR DESCRIPTION
Make it easier to read and maintain.
Also, remove an unnecessary public modifier from a test class.