### PR TITLE
Rework classpath setup for functional tests

### DIFF
--- a/plugin-project/plugin-project.gradle.kts
+++ b/plugin-project/plugin-project.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.plugin.devel.tasks.PluginUnderTestMetadata
+
 val functionalTest by sourceSets.creating {
     compileClasspath += sourceSets.main.get().output
     runtimeClasspath += sourceSets.main.get().output
@@ -9,7 +11,6 @@ val functionalTestImplementation by configurations.getting {
 
 val functionalTestRuntimeOnly by configurations.getting {
     extendsFrom(configurations.testRuntimeOnly.get())
-    extendsFrom(configurations.compileOnly.get())
 }
 
 dependencies {
@@ -28,24 +29,16 @@ val functionalTestTask =
         testClassesDirs = functionalTest.output.classesDirs
         classpath = functionalTest.runtimeClasspath
         mustRunAfter(tasks.test)
-        dependsOn(createFunctionalTestClasspathManifest)
     }
 
-val createFunctionalTestClasspathManifest =
-    tasks.register<Task>("createFunctionalTestClasspathManifest") {
-        description = "Creates a manifest file with the plugin classpath."
-        group = "build"
-        val outputDir = layout.buildDirectory.dir("resources/functionalTest")
-        inputs.files(functionalTest.runtimeClasspath)
-        outputs.dir(outputDir)
-        doLast {
-            val dir = outputDir.get().asFile
-            dir.mkdirs()
-            file("$dir/pluginClasspath.txt").writeText(
-                functionalTest.runtimeClasspath.joinToString("\n"),
-            )
-        }
-    }
+// Provide Spotless to functional tests.
+val functionalTestCompileOnlyRuntime by configurations.creating {
+    extendsFrom(configurations.compileOnly.get())
+}
+
+tasks.named<PluginUnderTestMetadata>("pluginUnderTestMetadata") {
+    pluginClasspath.from(functionalTestCompileOnlyRuntime)
+}
 
 tasks.check {
     dependsOn(functionalTestTask)

--- a/plugin-project/src/functionalTest/java/org/zaproxy/gradle/common/FunctionalTest.java
+++ b/plugin-project/src/functionalTest/java/org/zaproxy/gradle/common/FunctionalTest.java
@@ -21,10 +21,8 @@ package org.zaproxy.gradle.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.stream.Collectors;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
@@ -44,23 +42,11 @@ public abstract class FunctionalTest {
         createFile(content, projectDir.resolve("build.gradle.kts"));
     }
 
-    protected static Iterable<? extends File> pluginClasspath() throws Exception {
-        Path pluginClasspath =
-                Path.of(
-                        FunctionalTest.class
-                                .getClassLoader()
-                                .getResource("pluginClasspath.txt")
-                                .toURI());
-        return Files.readAllLines(pluginClasspath).stream()
-                .map(File::new)
-                .collect(Collectors.toList());
-    }
-
     protected BuildResult build(String... arguments) throws Exception {
         return GradleRunner.create()
                 .withProjectDir(projectDir.toFile())
                 .withArguments(arguments)
-                .withPluginClasspath(pluginClasspath())
+                .withPluginClasspath()
                 .build();
     }
 


### PR DESCRIPTION
Let Gradle do the generation of the file, pass the required configuration to the default task.